### PR TITLE
Add fallback definitions to Models

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,6 +10,7 @@
 .gitignore export-ignore
 .php_cs export-ignore
 .travis.yml export-ignore
+.styleci.yml export-ignore
 phpunit.xml.dist export-ignore
 CHANGELOG-* export-ignore
 CONTRIBUTING.md export-ignore

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,0 +1,6 @@
+preset: recommended
+disabled:
+  - new_with_braces
+finder:
+  exclude:
+    - "tests"

--- a/docs/post-models.md
+++ b/docs/post-models.md
@@ -6,15 +6,21 @@ To use Fresa's Post Model interface, create a new subclass of `Fresa\PostModel`.
 
     use Fresa\PostModel;
 
-    class Event extends PostModel
-    {
-        // Optionally define the post type
-        protected $postType = 'event';
-    }
+    class Event extends PostModel{}
 
 Once your subclass is defined, you can begin interacting with the existing WordPress data model right away.
 
-If you don't define a custom post type, Fresa assumes the default post type of `post`.
+## Post Types
+
+If you don't define a custom post type, Fresa will use the snake-case version of the class name. If you want to define a custom post type slug, update the `$postType` property:
+
+    use Fresa\PostModel;
+
+    class Event extends PostModel
+    {
+        // Optionally define the post type
+        protected $postType = 'custom_event';
+    }
 
 ## Accessing Default Properties
 

--- a/docs/taxonomy-models.md
+++ b/docs/taxonomy-models.md
@@ -10,7 +10,6 @@ Define a taxonomy by extending the base class:
 
     class EventCategory extends Taxonomy
     {
-        protected $taxonomy = 'event_category';
     }
 
 You can then interact with the taxonomy in an object-oriented fashion:
@@ -18,6 +17,23 @@ You can then interact with the taxonomy in an object-oriented fashion:
     $category = new EventCategory;
     $category->name = 'Celebrations';
     $category->save();
+
+## Defining Taxonomy Slugs
+
+By default, the snake-case version of the class name will be used as a slug to store the taxonomy terms in WordPress.
+
+    $e = new EventCategory;
+    $e->getTaxonomy(); // 'event_category'
+
+If you want to customize the taxonomy slug, set the `$taxonomy` variable on the class:
+
+
+    use Fresa\Taxonomy;
+
+    class EventCategory extends Taxonomy
+    {
+        protected $taxonomy = 'my_event_category';
+    }
 
 ## Querying Taxonomy Terms
 

--- a/src/PostModel.php
+++ b/src/PostModel.php
@@ -3,6 +3,7 @@
 namespace Fresa;
 
 use Carbon\Carbon;
+use Illuminate\Support\Str;
 
 /**
  * Post Model extends functionality onto the base Model class.
@@ -16,7 +17,7 @@ abstract class PostModel extends Model
      *
      * @var string
      */
-    protected $postType = 'post';
+    protected $postType = '';
 
     /**
      * The default keys on post models.
@@ -158,7 +159,13 @@ abstract class PostModel extends Model
      */
     public function getPostType()
     {
-        return $this->postType;
+        $postType = $this->postType;
+
+        if (empty($this->postType)) {
+            return Str::snake(static::class);
+        }
+
+        return $postType;
     }
 
     /**

--- a/src/Taxonomy.php
+++ b/src/Taxonomy.php
@@ -2,6 +2,8 @@
 
 namespace Fresa;
 
+use Illuminate\Support\Str;
+
 /**
  * Taxonomy abstract class.
  */
@@ -169,7 +171,11 @@ abstract class Taxonomy extends Model
      */
     public function getTaxonomy()
     {
-        return $this->taxonomy;
+        if (!empty($this->taxonomy)) {
+            return $this->taxonomy;
+        }
+
+        return Str::snake(static::class);
     }
 
     /**

--- a/tests/test-post-model.php
+++ b/tests/test-post-model.php
@@ -4,6 +4,8 @@
  */
 use Carbon\Carbon;
 
+use Fresa\PostModel;
+
 /**
  * Sample test case.
  */
@@ -179,4 +181,23 @@ class PostModelTest extends WP_UnitTestCase
         $this->assertNull(Event::find($id));
         $this->assertNull($event->id);
     }
+
+    public function test_post_model_types_can_be_inferred()
+    {
+        $e = $this->createEvent();
+        $this->assertEquals('event', $e->getPostType());
+
+        $s = new Student;
+        $this->assertEquals('student', $s->getPostType());
+
+        $cr = new CourseRecord;
+        $this->assertEquals('course_record', $cr->getPostType());
+    }
 }
+
+/**
+ * Test class definitions
+ */
+
+class Student extends PostModel{}
+class CourseRecord extends PostModel{}

--- a/tests/test-taxonomy.php
+++ b/tests/test-taxonomy.php
@@ -3,6 +3,8 @@
  * Class TaxonomyTest.
  */
 
+use Fresa\Taxonomy;
+
 /**
  * Sample test case.
  */
@@ -104,4 +106,22 @@ class TaxonomyTest extends WP_UnitTestCase
         $this->assertNull(Category::find($id));
         $this->assertNull($cat->id);
     }
+
+    public function test_taxonomy_can_be_inferred()
+    {
+        $cat = new Category;
+        $this->assertEquals('my_category', $cat->getTaxonomy());
+
+        $t = new Tag;
+        $this->assertEquals('tag', $t->getTaxonomy());
+
+        $d = new DevelopmentType;
+        $this->assertEquals('development_type', $d->getTaxonomy());
+    }
 }
+
+/**
+ * Test classes
+ */
+class Tag extends Taxonomy {}
+class DevelopmentType extends Taxonomy {}


### PR DESCRIPTION
### Purpose
This updates the `PostModel` and `Taxonomy` models to fall back to the child class name if `$postType` or `$taxonomy` is not defined on the model.

### Level of Changes
- **Minor**: Adds functionality, backwards compatible

### Tests
Yes!
