### PR TITLE
Fix name inferring

### DIFF
--- a/src/PostModel.php
+++ b/src/PostModel.php
@@ -162,7 +162,7 @@ abstract class PostModel extends Model
         $postType = $this->postType;
 
         if (empty($this->postType)) {
-            return Str::snake(static::class);
+            return Str::snake((new \ReflectionClass($this))->getShortName());
         }
 
         return $postType;

--- a/src/Taxonomy.php
+++ b/src/Taxonomy.php
@@ -175,7 +175,7 @@ abstract class Taxonomy extends Model
             return $this->taxonomy;
         }
 
-        return Str::snake(static::class);
+        return Str::snake((new \ReflectionClass(static::class))->getShortName());
     }
 
     /**

--- a/tests/Bar.php
+++ b/tests/Bar.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Foo;
+
+class Bar extends \Fresa\PostModel {
+
+}
+
+class Far extends \Fresa\Taxonomy {
+
+}

--- a/tests/plugin.php
+++ b/tests/plugin.php
@@ -3,6 +3,7 @@
 require dirname(dirname(__FILE__)).'/vendor/autoload.php';
 require dirname(__FILE__).'/Category.php';
 require dirname(__FILE__).'/Event.php';
+require dirname(__FILE__).'/Bar.php';
 
 Event::register();
 Category::register();

--- a/tests/test-post-model.php
+++ b/tests/test-post-model.php
@@ -192,6 +192,9 @@ class PostModelTest extends WP_UnitTestCase
 
         $cr = new CourseRecord;
         $this->assertEquals('course_record', $cr->getPostType());
+
+        $bar = new Foo\Bar;
+        $this->assertEquals('bar', $bar->getPostType());
     }
 }
 

--- a/tests/test-taxonomy.php
+++ b/tests/test-taxonomy.php
@@ -117,6 +117,9 @@ class TaxonomyTest extends WP_UnitTestCase
 
         $d = new DevelopmentType;
         $this->assertEquals('development_type', $d->getTaxonomy());
+
+        $f = new Foo\Far;
+        $this->assertEquals('far', $f->getTaxonomy());
     }
 }
 


### PR DESCRIPTION
### Purpose
Fixes an issue where class names with Namespaces would be inferred with the Namespace in them, breaking what you would expect to see for an inferred `post_type`.

### Level of Changes
- **Patch**: Bugfixes, Small enhancements

### Tests
Yes

### Docs
No need.
